### PR TITLE
Add lz4.decompress as an alias to lz4.uncompress.

### DIFF
--- a/lz4/__init__.py
+++ b/lz4/__init__.py
@@ -89,7 +89,7 @@ def uncompress(source):
     data, size = _uncompress(source)
     return ffi.buffer(data, size)[:]
 
-loads = uncompress
+loads = decompress = uncompress
 dumps = compress
 
-__all__ = ['compress', 'compressHC', 'uncompress', 'loads', 'dumps']
+__all__ = ['compress', 'compressHC', 'uncompress', 'decompress', 'loads', 'dumps']


### PR DESCRIPTION
Needed for drop-in compatibility with the normal Python lz4 library.
